### PR TITLE
fix: add required arg for html5 support

### DIFF
--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -225,10 +225,20 @@ class Hooks {
 
 		register_nav_menus( $menus );
 
+		$html5_features = [
+			'comment-list',
+			'comment-form',
+			'search-form',
+			'gallery',
+			'caption',
+			'style',
+			'script'
+		];
+
+		add_theme_support( 'html5', $html5_features );
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'title-tag' );
 		add_theme_support( 'custom-logo' );
-		add_theme_support( 'html5' );
 		add_theme_support( 'automatic-feed-links' );
 	}
 

--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -225,7 +225,7 @@ class Hooks {
 
 		register_nav_menus( $menus );
 
-		add_theme_support( 'html5', [
+		$html5_features = [
 			'comment-list',
 			'comment-form',
 			'search-form',
@@ -233,7 +233,9 @@ class Hooks {
 			'caption',
 			'style',
 			'script',
-		] );
+		];
+
+		add_theme_support( 'html5', $html5_features );
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'title-tag' );
 		add_theme_support( 'custom-logo' );

--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -232,7 +232,7 @@ class Hooks {
 			'gallery',
 			'caption',
 			'style',
-			'script'
+			'script',
 		];
 
 		add_theme_support( 'html5', $html5_features );

--- a/includes/class-hooks.php
+++ b/includes/class-hooks.php
@@ -225,7 +225,7 @@ class Hooks {
 
 		register_nav_menus( $menus );
 
-		$html5_features = [
+		add_theme_support( 'html5', [
 			'comment-list',
 			'comment-form',
 			'search-form',
@@ -233,9 +233,7 @@ class Hooks {
 			'caption',
 			'style',
 			'script',
-		];
-
-		add_theme_support( 'html5', $html5_features );
+		] );
 		add_theme_support( 'post-thumbnails' );
 		add_theme_support( 'title-tag' );
 		add_theme_support( 'custom-logo' );


### PR DESCRIPTION
Addresses warning by adding all supported features in required array:

> Notice: Function add_theme_support( 'html5' ) was called incorrectly. You need to pass an array of types. Please see [Debugging in WordPress](https://wordpress.org/support/article/debugging-in-wordpress/) for more information. (This message was added in version 3.6.1.) in /srv/www/elections/public_html/wp-includes/functions.php on line 5835

Docs: https://developer.wordpress.org/reference/functions/add_theme_support/#html5