### PR TITLE
fix: update block_categories filter to block_categories_all

### DIFF
--- a/includes/blocks/class-blocks.php
+++ b/includes/blocks/class-blocks.php
@@ -20,7 +20,7 @@ class Blocks {
 	 */
 	public static function hooks() {
 		add_action( 'init', [ __CLASS__, 'init_block_editors' ] );
-		add_filter( 'block_categories', [ __CLASS__, 'block_categories' ], 10, 2 );
+		add_filter( 'block_categories_all', [ __CLASS__, 'block_categories' ], 10, 2 );
 	}
 
 	/**


### PR DESCRIPTION
## Background

Addresses warning with updated function name:

> Hook block_categories is deprecated since version 5.8.0! Use block_categories_all instead. in /srv/www/elections/public_html/wp-includes/functions.php on line 5758

This warning causes a momentary flash when navigating to edit a page.

Docs: https://developer.wordpress.org/reference/hooks/block_categories_all/

## Testing

Verified custom "Election Blocks" category is still present at top of Blocks menu, in VVV dev env