### PR TITLE
fix: contact form post-submit 'Go back' link

### DIFF
--- a/template-parts/mail-success.php
+++ b/template-parts/mail-success.php
@@ -13,4 +13,4 @@ $file = get_template_directory() . '/assets/images/checkmark.svg';
 
 <p>We’ve received your message and will respond as soon as possible. In the meantime, you may find helpful information in our <a href="/faq/">Frequently Asked Questions</a>.</p>
 
-<p><a href="/about-us/">Go back</a></p>
+<p><a href="javascript:window.history.back();">Go back</a></p>


### PR DESCRIPTION
### Context
- A client raised a broken link bug, for the "Go back" link on the contact form post-submission message
- The link directs to an `/about-us` page that does not exist

### Fix
- Direct back link to previous page in browser history (like on the [error message](https://github.com/CTCL/election-websites/blob/master/template-parts/mail-error.php#L22))

### Testing
- Tested link on VVV dev env (Chrome, Safari)
- Tested on [sample website](https://electionwebsitetemplate.org/)