### PR TITLE
Updater: Fix fatal error in PHP 8 when attempting to call a non-static method statically

### DIFF
--- a/includes/class-updater.php
+++ b/includes/class-updater.php
@@ -128,7 +128,7 @@ class Updater {
 	 *
 	 * @return string
 	 */
-	public function upgrader_source_selection( $source, $remote_souce, $upgrader, $hook_extra ) {
+	public static function upgrader_source_selection( $source, $remote_souce, $upgrader, $hook_extra ) {
 		$theme_folder = get_option( 'template' );
 
 		if ( false === strpos( $source, $theme_folder ) ) {


### PR DESCRIPTION
While debugging update failures on a site on WordPress.com I came across the following fatal error:

```
PHP Fatal error: Uncaught TypeError: call_user_func_array(): Argument #1 ($callback) must be a valid callback, non-static method CTCL\Elections\Updater::upgrader_source_selection() cannot be called statically in /wordpress/core/6.5.2/wp-includes/class-wp-hook.php:324
```

The site is running on PHP 8.1 with CTCL Election Website template version 0.9.5.

I hope this helps, please let me know if there's any additional context I can provide.